### PR TITLE
Switch to ADD instead of curl

### DIFF
--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -49,10 +49,15 @@ RUN mkdir "${APP_DIR}" && \
 ARG S6_VERSION=3.1.5.0
 
 # install s6-overlay
-RUN curl -fsSL "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-noarch.tar.xz" | tar Jpxf - -C / && \
-    curl -fsSL "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-x86_64.tar.xz" | tar Jpxf - -C / && \
-    curl -fsSL "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-symlinks-noarch.tar.xz" | tar Jpxf - -C / && \
-    curl -fsSL "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-symlinks-arch.tar.xz" | tar Jpxf - -C /
+ADD "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-noarch.tar.xz" \
+    "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-x86_64.tar.xz" \
+    "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    /tmp/
+RUN tar Jpxf /tmp/s6-overlay-noarch.tar.xz -C / && \
+    tar Jpxf /tmp/s6-overlay-x86_64.tar.xz -C / && \
+    tar Jpxf /tmp/s6-overlay-symlinks-noarch.tar.xz -C / && \
+    tar Jpxf /tmp/s6-overlay-symlinks-arch.tar.xz -C / 
 
 ARG BUILD_ARCHITECTURE
 ENV BUILD_ARCHITECTURE=$BUILD_ARCHITECTURE

--- a/linux-arm64.Dockerfile
+++ b/linux-arm64.Dockerfile
@@ -49,10 +49,15 @@ RUN mkdir "${APP_DIR}" && \
 ARG S6_VERSION=3.1.5.0
 
 # install s6-overlay
-RUN curl -fsSL "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-noarch.tar.xz" | tar Jpxf - -C / && \
-    curl -fsSL "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-aarch64.tar.xz" | tar Jpxf - -C / && \
-    curl -fsSL "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-symlinks-noarch.tar.xz" | tar Jpxf - -C / && \
-    curl -fsSL "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-symlinks-arch.tar.xz" | tar Jpxf - -C /
+ADD "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-noarch.tar.xz" \
+    "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-aarch64.tar.xz" \
+    "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    /tmp/
+RUN tar Jpxf /tmp/s6-overlay-noarch.tar.xz -C / && \
+    tar Jpxf /tmp/s6-overlay-x86_64.tar.xz -C / && \
+    tar Jpxf /tmp/s6-overlay-symlinks-noarch.tar.xz -C / && \
+    tar Jpxf /tmp/s6-overlay-symlinks-arch.tar.xz -C / 
 
 ARG BUILD_ARCHITECTURE
 ENV BUILD_ARCHITECTURE=$BUILD_ARCHITECTURE


### PR DESCRIPTION
## Problem
According to the s6-overlay documentation, the image should use `ADD` instead of `curl` when importing the tarballs. However, this may have already been considered, so feel free to disregard if this is not a useful change.

### `s6-overlay` documentation
https://github.com/just-containers/s6-overlay?tab=readme-ov-file#usage