### PR TITLE
fix: allow to use filesystems that dont support chown

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-privoxy/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-privoxy/run
@@ -7,5 +7,5 @@ if [[ ! -f "${CONFIG_DIR}/privoxy/privoxy.conf" ]] && [[ "${PRIVOXY_ENABLED}" ==
 	echo "Installing default \"privoxy.conf\"..."
 	mkdir -p "${CONFIG_DIR}/privoxy"
 	cp "${APP_DIR}/privoxy.conf" "${CONFIG_DIR}/privoxy/privoxy.conf"
-	chown hotio:hotio -R "${CONFIG_DIR}/privoxy"
+	find "${CONFIG_DIR}/privoxy" \( ! -user hotio -or ! -group hotio \) -exec chown hotio:hotio {} +
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-setup/run
@@ -59,4 +59,4 @@ groupmod -o -g "${PGID}" hotio
 
 echo "Applying permissions to ${CONFIG_DIR}"
 chmod "=rwx" "${CONFIG_DIR}"
-chown hotio:hotio "${CONFIG_DIR}"
+find "${CONFIG_DIR}" -maxdepth 0 \( ! -user hotio -or ! -group hotio \) -exec chown hotio:hotio {} +

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard/run.up
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard/run.up
@@ -5,13 +5,13 @@ umask "${UMASK}"
 
 if [[ ${VPN_ENABLED} == "true" ]] && [[ ! -d "${CONFIG_DIR}/wireguard/" ]]; then
 	mkdir -p "${CONFIG_DIR}/wireguard"
-	chown hotio:hotio "${CONFIG_DIR}/wireguard"
+	find "${CONFIG_DIR}/wireguard" -maxdepth 0 \( ! -user hotio -or ! -group hotio \) -exec chown hotio:hotio {} +
 fi
 
 if [[ ${VPN_ENABLED} == "true" ]] && [[ ${VPN_PROVIDER} == "pia" ]]; then
 	echo "[INF] [$(date '+%Y-%m-%d %H:%M:%S')] [PIA] Downloading regions list to \"${CONFIG_DIR}/wireguard/pia-regions.txt\"..."
 	curl -fsSL https://serverlist.piaservers.net/vpninfo/servers/v6 | head -1 | jq -r '"Region|Name|Port Forwarding", "------|----|---------------", (.regions[] | "\(.id)|\(.name)|\(.port_forward)")' | awk 'NR<3{print $0;next}{print $0| "sort"}' | column -t -c 3 -s "|" > "${CONFIG_DIR}/wireguard/pia-regions.txt"
-	chown hotio:hotio "${CONFIG_DIR}/wireguard/pia-regions.txt"
+	find "${CONFIG_DIR}/wireguard/pia-regions.txt" -maxdepth 0 \( ! -user hotio -or ! -group hotio \) -exec chown hotio:hotio {} +
 fi
 
 if [[ ${VPN_ENABLED} == "true" ]] && [[ ${VPN_PROVIDER} == "pia" ]] && [[ ! -f "${CONFIG_DIR}/wireguard/${VPN_CONF}.json" ]]; then
@@ -27,14 +27,14 @@ if [[ ${VPN_ENABLED} == "true" ]] && [[ ${VPN_PROVIDER} == "pia" ]] && [[ ! -f "
 	cd "${APP_DIR}/pia-scripts"
 	if output=$(PIA_USER=${VPN_PIA_USER} PIA_PASS=${VPN_PIA_PASS} PREFERRED_REGION=${VPN_PIA_PREFERRED_REGION} DISABLE_IPV6=${pia_ipv6} AUTOCONNECT="" PIA_CONNECT="false" PIA_PF="${VPN_AUTO_PORT_FORWARD}" VPN_PROTOCOL=wireguard PIA_CONF_PATH="${CONFIG_DIR}/wireguard/${VPN_CONF}.conf" DIP_TOKEN=no PIA_DNS=true timeout 60s "./run_setup.sh"); then
 		wg_hostname=$(grep -Po '(?<=WG_HOSTNAME=)[^ ]+' <<< "${output}")
-    	wg_server_ip=$(grep -Po '(?<=WG_SERVER_IP=)[^ ]+' <<< "${output}")
+		wg_server_ip=$(grep -Po '(?<=WG_SERVER_IP=)[^ ]+' <<< "${output}")
 		jq '.hostname = "'"${wg_hostname}"'" | .ip = "'"${wg_server_ip}"'"' <<< "{}" > "${CONFIG_DIR}/wireguard/${VPN_CONF}.json"
-		chown hotio:hotio "${CONFIG_DIR}/wireguard/${VPN_CONF}.json"
+		find "${CONFIG_DIR}/wireguard/${VPN_CONF}.json" -maxdepth 0 \( ! -user hotio -or ! -group hotio \) -exec chown hotio:hotio {} +
 		chmod 600 "${CONFIG_DIR}/wireguard/${VPN_CONF}.json"
 		echo "[INF] [$(date '+%Y-%m-%d %H:%M:%S')] [PIA] WireGuard config written to \"${CONFIG_DIR}/wireguard/${VPN_CONF}.conf\"."
 	else
 		echo "${output}" > "${CONFIG_DIR}/wireguard/pia.log"
-		chown hotio:hotio "${CONFIG_DIR}/wireguard/pia.log"
+		find "${CONFIG_DIR}/wireguard/pia.log" -maxdepth 0 \( ! -user hotio -or ! -group hotio \) -exec chown hotio:hotio {} +
 		echo "[ERR] [$(date '+%Y-%m-%d %H:%M:%S')] [PIA] Something went wrong trying to get a WireGuard config. See log file \"${CONFIG_DIR}/wireguard/pia.log\". Exiting..."
 		exit 1
 	fi
@@ -71,7 +71,7 @@ if [[ ${VPN_ENABLED} == "true" ]]; then
 		echo "[ERR] [$(date '+%Y-%m-%d %H:%M:%S')] [VPN] Configuration file \"${CONFIG_DIR}/wireguard/${VPN_CONF}.conf\" was not found. Exiting..."
 		exit 1
 	else
-		chown hotio:hotio "${CONFIG_DIR}/wireguard/${VPN_CONF}.conf"
+		find "${CONFIG_DIR}/wireguard/${VPN_CONF}.conf" -maxdepth 0 \( ! -user hotio -or ! -group hotio \) -exec chown hotio:hotio {} +
 		chmod 600 "${CONFIG_DIR}/wireguard/${VPN_CONF}.conf"
 	fi
 


### PR DESCRIPTION
nfs mounts for example do not support chowning something, so the containers cannot run if an nfs mount is used as config folder