### PR TITLE
Do not fail on already existing routes

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard/run.up
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard/run.up
@@ -192,12 +192,12 @@ if [[ ${VPN_ENABLED} == "true" ]]; then
 
     IFS=',' read -ra lan_networks <<< "${VPN_LAN_NETWORK%,}"
     for lan_network in "${lan_networks[@]}"; do
-        ip route add "${lan_network}" via "${nw_gateway}" dev "${nw_interface}"
+        ip route replace "${lan_network}" via "${nw_gateway}" dev "${nw_interface}"
         echo "[INF] [$(date '+%Y-%m-%d %H:%M:%S')] [VPN] Added [${lan_network}][LAN] as route via interface [${nw_interface}]."
     done
 
     if [[ "${VPN_CONF}" == *"-fix" ]]; then
-        ip route add "${vpn_endpoint_ip}" via "${nw_gateway}" dev "${nw_interface}"
+        ip route replace "${vpn_endpoint_ip}" via "${nw_gateway}" dev "${nw_interface}"
         echo "[INF] [$(date '+%Y-%m-%d %H:%M:%S')] [VPN] Added [${vpn_endpoint_ip}][${VPN_CONF}] as route via interface [${nw_interface}]."
     fi
 


### PR DESCRIPTION
Rely on `ip route replace` instead of `ip route add` to gracefully handle already existing routes. This may happen when restarting s6 scripts in an already running container (such as when qbittorrent get OOMKilled).

Issue can easily be reproduced by manually killing in the pod (with some networks in VPN_LAN_NETWORK):
```
qbittorrent-776df8c44-58b2b:/# ps aux
PID   USER     TIME  COMMAND
    1 root      0:00 /package/admin/s6/command/s6-svscan -d4 -- /run/service
   17 root      0:00 s6-supervise s6-linux-init-shutdownd
   19 root      0:00 /package/admin/s6-linux-init/command/s6-linux-init-shutdownd -d3 -c /run/s6/basedir -g 3000 -C -B
   35 root      0:00 s6-supervise service-unbound
   36 root      0:00 s6-supervise s6rc-oneshot-runner
   37 root      0:00 s6-supervise service-forwarder
   38 root      0:00 s6-supervise service-pia
   39 root      0:00 s6-supervise s6rc-fdholder
   40 root      0:00 s6-supervise service-qbittorrent
   41 root      0:00 s6-supervise service-privoxy
   42 root      0:00 s6-supervise service-healthcheck
   43 root      0:00 s6-supervise service-proton
   51 root      0:00 /package/admin/s6/command/s6-ipcserverd -1 -- /package/admin/s6/command/s6-ipcserver-access -v0 -E -l0 -i data/rules -- /package/admin/s6/command/s6-sudod -t 30000 -- /package/admin/s6-rc/command/s6-rc-oneshot-run -l ../.. --
  363 hotio     0:32 /app/qbittorrent-nox --profile=/app --webui-port=8080
  364 root      0:00 bash ./run service-proton
  365 root      0:00 bash ./run service-forwarder
  524 root      0:00 sleep 45
  526 root      0:00 sleep 60
  527 root      0:00 bash
  533 root      0:00 ps aux
qbittorrent-776df8c44-58b2b:/# kill 1 363
```

Then it fails in loop when trying to restart:
```
...
 qbittorrent-qbittorrent [INF] [2024-12-09 19:15:43] [VPN] WireGuard [wg0] allowed ips [0.0.0.0/0]. 
 qbittorrent-qbittorrent [INF] [2024-12-09 19:15:43] [VPN] Network [default][eth0][10.42.0.44][10.42.0.0/24]. 
 qbittorrent-qbittorrent RTNETLINK answers: File exists 
 qbittorrent-qbittorrent s6-rc: warning: unable to start service init-wireguard: command exited 2
...
```