### PR TITLE
Do not fail on already existing routes - jammy

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard/run.up
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard/run.up
@@ -192,12 +192,12 @@ if [[ ${VPN_ENABLED} == "true" ]]; then
 
     IFS=',' read -ra lan_networks <<< "${VPN_LAN_NETWORK%,}"
     for lan_network in "${lan_networks[@]}"; do
-        ip route add "${lan_network}" via "${nw_gateway}" dev "${nw_interface}"
+        ip route replace "${lan_network}" via "${nw_gateway}" dev "${nw_interface}"
         echo "[INF] [$(date '+%Y-%m-%d %H:%M:%S')] [VPN] Added [${lan_network}][LAN] as route via interface [${nw_interface}]."
     done
 
     if [[ "${VPN_CONF}" == *"-fix" ]]; then
-        ip route add "${vpn_endpoint_ip}" via "${nw_gateway}" dev "${nw_interface}"
+        ip route replace "${vpn_endpoint_ip}" via "${nw_gateway}" dev "${nw_interface}"
         echo "[INF] [$(date '+%Y-%m-%d %H:%M:%S')] [VPN] Added [${vpn_endpoint_ip}][${VPN_CONF}] as route via interface [${nw_interface}]."
     fi
 


### PR DESCRIPTION
Sister PR of #24, for jammy branch.

Rely on `ip route replace` instead of `ip route add` to gracefully handle already existing routes. This may happen when restarting s6 scripts in an already running container.