### PR TITLE
ci: scope reusable-workflow concurrency groups to avoid cross-cancellation

### DIFF
--- a/.github/workflows/build-on-call.yml
+++ b/.github/workflows/build-on-call.yml
@@ -1,7 +1,7 @@
 name: build-on-call
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.ref_name }}
+  group: ${{ github.repository }}-build-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/update-on-call.yml
+++ b/.github/workflows/update-on-call.yml
@@ -1,9 +1,5 @@
 name: update-on-call
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.ref_name }}
-  cancel-in-progress: true
-
 on:
   workflow_call:
 
@@ -24,6 +20,9 @@ jobs:
 
   update:
     needs: get-branches
+    concurrency:
+      group: ${{ github.repository }}-update-${{ matrix.branches }}
+      cancel-in-progress: true
     strategy:
       matrix:
         branches: ${{ fromJSON(needs.get-branches.outputs.branches) }}


### PR DESCRIPTION
## Why

Both `update-on-call.yml` and `build-on-call.yml` declare the same workflow-level concurrency group:

```yaml
concurrency:
  group: ${{ github.repository }}-${{ github.ref_name }}
  cancel-in-progress: true
```

In a `workflow_call`, `github.ref_name` resolves to the caller's ref, not the matrix branch. So all matrix branches inside `call-update` share one group, and that same group is used by `call-build` on the same ref.

When `update (release)` pushes a version-bump commit, the resulting `call-build@release` enters the same group and cancels the still-running `update (nightly)`. The nightly branch silently stops being updated.

The race is invisible in `hotio/*` history because each repo's `call-update` fires on its own cron. It surfaces under any parallel fan-out across repos. My image repos sync their CI from `hotio/base@workflows` and therefore run these workflows unmodified, so the bug is latent on `hotio/*` too.

Witness on my side: `engels74/zondarr-docker` run [25916715031](https://github.com/engels74/zondarr-docker/actions/runs/25916715031). `update (release)` succeeded, `update (nightly)` was cancelled by the sibling build, the `nightly` branch did not advance.

## What

- `update-on-call.yml`: move `concurrency` to job-level on the `update` job, keyed by `matrix.branches`, so distinct matrix branches no longer share a group.
- `build-on-call.yml`: prefix the group with `-build-` so build runs no longer cancel update runs on the same ref.

I have been running this patch on my downstream fork across the same matrix-branch set for several hours with no observable side effects.