### PR TITLE
fix(build): preserve packages.txt when upstream-diff filter empties it

### DIFF
--- a/.github/workflows/build-on-call.yml
+++ b/.github/workflows/build-on-call.yml
@@ -137,7 +137,7 @@ jobs:
             upstream_tag=$(jq -re '.upstream_tag' < meta.json)
             upstream_sha=${upstream_tag_sha//${upstream_tag}-/}
             upstream_packages_txt=$(curl -fsSL "https://raw.githubusercontent.com/${upstream_image}/${upstream_sha}/packages.txt")
-            rm -f packages.txt
+            rm -f packages.txt && touch packages.txt
             while read -r line; do
                 package="${line%%=*}"
                 grep -q "${package}" <<< "${upstream_packages_txt}" || echo "${line}" >> packages.txt

--- a/.github/workflows/update-on-call.yml
+++ b/.github/workflows/update-on-call.yml
@@ -73,7 +73,7 @@ jobs:
             upstream_tag=$(jq -re '.upstream_tag' < meta.json)
             upstream_sha=${upstream_tag_sha//${upstream_tag}-/}
             upstream_packages_txt=$(curl -fsSL "https://raw.githubusercontent.com/${upstream_image}/${upstream_sha}/packages.txt")
-            rm -f packages.txt
+            rm -f packages.txt && touch packages.txt
             while read -r line; do
                 package="${line%%=*}"
                 grep -q "${package}" <<< "${upstream_packages_txt}" || echo "${line}" >> packages.txt


### PR DESCRIPTION
## Problem

When a downstream image builds `FROM` a base that publishes `packages.txt` and adds zero packages of its own, the upstream-diff filter in the **Update packages.txt** step (in both `build-on-call.yml` and `update-on-call.yml`) removes every line and leaves no file behind — `rm -f packages.txt` is followed by a `while ... >> packages.txt` loop that never appends.

`actions/upload-artifact@v7` with `if-no-files-found: warn` then creates **no artifact at all** when neither `packages.txt` nor `smoketest.log` exists (the latter is missing when `test_amd64`/`test_arm64` are `false` in `meta.json`), and the `packages` job's `actions/download-artifact@v8` hard-fails:

```
##[error]Unable to download artifact(s): Artifact not found for name: <branch>-<sha>-results-linux-amd64
```

Reproduces in any downstream of `hotio/base` that sets `upstream_tag_sha` in `meta.json`, has zero added packages, and disables smoke tests. The same shape exists in `update-on-call.yml`'s cron path, where it silently commits an empty `packages.txt` to the repo.

## Fix

Truncating in place (`: > packages.txt`) fails with `Permission denied`: the docker container writes `packages.txt` as root via the mounted workspace volume, and the runner shell can't open the root-owned file for writing. Removing then re-creating works because removal only needs write access to the *directory* (which the runner has), and `touch` then creates a fresh runner-owned empty file the `>> packages.txt` loop can append to.

```diff
-            rm -f packages.txt
+            rm -f packages.txt && touch packages.txt
```

Applied to both `.github/workflows/build-on-call.yml` and `.github/workflows/update-on-call.yml`. Net effect: `packages.txt` is always present after the step (empty when no fork-specific packages remain), the artifact handoff works, and the `packages` job's commit step still no-ops on an empty diff (`git diff --staged` is empty -> `git commit` exits non-zero -> no spurious push).

## Before / after evidence

Same downstream (`engels74/otpravkarr-docker`), same workflow:

- **Before** - original failure with `rm -f packages.txt`: [run 26343445526](https://github.com/engels74/otpravkarr-docker/actions/runs/26343445526) -> `Upload Artifacts` warns `No files were found with the provided path: packages.txt smoketest.log`; `packages` job's `Download Artifacts` fails with `Artifact not found`.
- **After** - same repo with this fix applied via a temporary patch on the `engels74/base-image` mirror: [run 26359221552](https://github.com/engels74/otpravkarr-docker/actions/runs/26359221552) -> all jobs green; the upload finalises the `nightly-...-results-linux-amd64` artifact (140 B, containing the empty `packages.txt`), and the packages job logs `Artifact download completed successfully`.

## Notes

- The same fix lands in `update-on-call.yml`; the cron path doesn't fail on missing `packages.txt` (it just silently commits an empty file), but the fix removes the latent inconsistency between the two code paths.
- `continue-on-error: true` on the packages job's `Download Artifacts` step was considered as a minimal alternative but rejected: it masks any future upload-side regression instead of fixing the root cause.